### PR TITLE
replace deprecated helm stable repo location

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -117,7 +117,9 @@ setup_helm() {
   tillerless=$(jq -r '.source.tillerless // "false"' < $payload)
   tls_enabled=$(jq -r '.source.tls_enabled // "false"' < $payload)
   history_max=$(jq -r '.source.helm_history_max // "0"' < $1)
-  stable_repo=$(jq -r '.source.stable_repo // ""' < $payload)
+  # set default helm charts repository as the old default was deprecated
+  # see https://helm.sh/blog/charts-repo-deprecation/
+  stable_repo=$(jq -r '.source.stable_repo // "https://charts.helm.sh/stable"' < $payload)
 
   if [ "$tillerless" = true ]; then
     echo "Using tillerless helm"

--- a/ci/pipelines/master.yml
+++ b/ci/pipelines/master.yml
@@ -1,0 +1,103 @@
+resource_types:
+- name: slack-notification
+  type: registry-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+
+resources:
+- name: repo
+  webhook_token: ((github-webhook-token))
+  type: git
+  check_every: 15m
+  source:
+    branch: master
+    password: ((git-password))
+    uri: https://github.com/OdekoTeam/concourse-helm-resource.git
+    username: ((git-user))
+- name: concourse
+  type: git
+  check_every: 1h
+  source:
+    branch: master
+    password: ((git-password))
+    uri: https://github.com/OdekoTeam/concourse.git
+    username: ((git-user))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: ((slack-build-webhook-token))
+- name: concourse-helm-resource
+  type: registry-image
+  source:
+    repository: docker.odeko.com/linkyard/concourse-helm-resource
+
+jobs:
+- name: build-concourse-helm-resource
+  serial: true
+  plan:
+  - in_parallel:
+    - get: repo
+      trigger: true
+    - get: concourse
+  - task: build-concourse-helm-resource
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: vito/oci-build-task
+      params:
+        DOCKERFILE: repo/Dockerfile
+        CONTEXT: repo
+      inputs:
+      - name: repo
+      outputs:
+      - name: image
+      caches:
+      - path: cache
+      run:
+        path: build
+  - put: concourse-helm-resource
+    params:
+      image: image/image.tar
+  on_failure:
+    do:
+    - task: slack-message
+      file: concourse/tasks/common/slack_master_message.yml
+    - put: slack-alert
+      params:
+        username: 'concourse'
+        icon_url: https://concourse-ci.org/images/trademarks/concourse-black.png
+        text_file: slack-message/slack-info
+        text: |
+          :red_circle: *${BUILD_PIPELINE_NAME} job ${BUILD_JOB_NAME}/${BUILD_NAME} failed*
+          See <https://concourse.odeko.com/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}|concourse> for more information.
+          $TEXT_FILE_CONTENT
+        silent: true
+      attempts: 3
+- name: notify-complete
+  serial: true
+  plan:
+  - in_parallel:
+    - get: repo
+      passed:
+      - build-concourse-helm-resource
+      trigger: true
+    - get: concourse
+  on_success:
+    do:
+    - task: slack-message
+      file: concourse/tasks/common/slack_master_message.yml
+    - put: slack-alert
+      params:
+        username: 'concourse'
+        icon_url: https://concourse-ci.org/images/trademarks/concourse-black.png
+        text_file: slack-message/slack-info
+        text: |
+          :thumbsup: *${BUILD_PIPELINE_NAME} job ${BUILD_JOB_NAME}/${BUILD_NAME} succeeded*
+          See <https://concourse.odeko.com/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}|concourse> for more information.
+          $TEXT_FILE_CONTENT
+        silent: true
+      attempts: 3

--- a/ci/pipelines/master.yml
+++ b/ci/pipelines/master.yml
@@ -77,15 +77,6 @@ jobs:
           $TEXT_FILE_CONTENT
         silent: true
       attempts: 3
-- name: notify-complete
-  serial: true
-  plan:
-  - in_parallel:
-    - get: repo
-      passed:
-      - build-concourse-helm-resource
-      trigger: true
-    - get: concourse
   on_success:
     do:
     - task: slack-message

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -1,0 +1,115 @@
+resource_types:
+- name: pull-request
+  type: registry-image
+  source:
+    repository: teliaoss/github-pr-resource
+- name: slack-notification
+  type: registry-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag: latest
+
+resources:
+- name: pull-request
+  type: pull-request
+  check_every: 15m
+  webhook_token: ((github-webhook-token))
+  source:
+    repository: OdekoTeam/concourse-helm-resource
+    access_token: ((git-release-token))
+- name: concourse
+  type: git
+  check_every: 1h
+  source:
+    branch: master
+    password: ((git-password))
+    uri: https://github.com/OdekoTeam/concourse.git
+    username: ((git-user))
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: ((slack-build-webhook-token))
+
+jobs:
+- name: build-concourse-helm-resource
+  plan:
+  - in_parallel:
+    - get: pull-request
+      trigger: true
+    - get: concourse
+  - in_parallel:
+    - put: pull-request
+      params:
+        path: pull-request
+        context: build-concourse-helm-resource
+        status: pending
+      attempts: 3
+    - task: build-concourse-helm-resource
+      privileged: true
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source:
+            repository: vito/oci-build-task
+        params:
+          DOCKERFILE: pull-request/Dockerfile
+          CONTEXT: pull-request
+        inputs:
+        - name: pull-request
+        outputs:
+        - name: image
+        caches:
+        - path: cache
+        run:
+          path: build
+  on_failure:
+    do:
+    - in_parallel:
+      - put: pull-request
+        params:
+          path: pull-request
+          context: build-concourse-helm-resource
+          status: failure
+        attempts: 3
+      - task: slack-message
+        file: concourse/tasks/common/slack_pr_message.yml
+    - put: slack-alert
+      params:
+        username: 'concourse'
+        icon_url: https://concourse-ci.org/images/trademarks/concourse-black.png
+        text_file: slack-message/slack-info
+        text: |
+          :red_circle: *<https://concourse.odeko.com/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}|${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME}/${BUILD_NAME}> failed*
+          $TEXT_FILE_CONTENT
+        silent: true
+      attempts: 3
+  on_success:
+    do:
+    - put: pull-request
+      params:
+        path: pull-request
+        context: build-concourse-helm-resource
+        status: success
+      attempts: 3
+- name: notify-complete
+  serial: true
+  plan:
+  - in_parallel:
+    - get: pull-request
+      passed:
+      - build-concourse-helm-resource
+      trigger: true
+    - get: concourse
+  - task: slack-message
+    file: concourse/tasks/common/slack_pr_message.yml
+  - put: slack-alert
+    params:
+      username: 'concourse'
+      icon_url: https://concourse-ci.org/images/trademarks/concourse-black.png
+      text_file: slack-message/slack-info
+      text: |
+        :thumbsup: *<https://concourse.odeko.com/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}|${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME}/${BUILD_NAME}> succeeded*
+        $TEXT_FILE_CONTENT
+      silent: true
+    attempts: 3

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -92,24 +92,13 @@ jobs:
         context: build-concourse-helm-resource
         status: success
       attempts: 3
-- name: notify-complete
-  serial: true
-  plan:
-  - in_parallel:
-    - get: pull-request
-      passed:
-      - build-concourse-helm-resource
-      trigger: true
-    - get: concourse
-  - task: slack-message
-    file: concourse/tasks/common/slack_pr_message.yml
-  - put: slack-alert
-    params:
-      username: 'concourse'
-      icon_url: https://concourse-ci.org/images/trademarks/concourse-black.png
-      text_file: slack-message/slack-info
-      text: |
-        :thumbsup: *<https://concourse.odeko.com/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}|${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME}/${BUILD_NAME}> succeeded*
-        $TEXT_FILE_CONTENT
-      silent: true
-    attempts: 3
+    - put: slack-alert
+      params:
+        username: 'concourse'
+        icon_url: https://concourse-ci.org/images/trademarks/concourse-black.png
+        text_file: slack-message/slack-info
+        text: |
+          :thumbsup: *<https://concourse.odeko.com/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}|${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME}/${BUILD_NAME}> succeeded*
+          $TEXT_FILE_CONTENT
+        silent: true
+      attempts: 3


### PR DESCRIPTION
Updates the "stable" Helm repo location as the old location is no longer supported.

See:
- https://helm.sh/blog/charts-repo-deprecation/
- https://helm.sh/docs/faq/#i-am-getting-the-warning-warning-kubernetes-chartsstoragegoogleapiscom-is-deprecated-for-stable-and-will-be-deleted-nov-13-2020

![helm-v2-stable-deprecation](https://user-images.githubusercontent.com/234523/102811343-35650b00-4393-11eb-8a58-5d8962bd7e19.png)
